### PR TITLE
chore: promote footest to version 0.0.2 in Staging environment

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,9 +9,12 @@ repositories:
   url: http://chartmuseum-jx.34.121.209.58.nip.io/
 releases:
 - chart: dev/footest
-  version: 0.0.1
+  version: 0.0.2
   name: footest
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote footest to version 0.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge